### PR TITLE
Makes meteor math great again.

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -1,8 +1,9 @@
 /datum/game_mode/meteor
 	name = "meteor"
 	config_tag = "meteor"
-	var/const/meteordelay = 2000
-	var/nometeors = 1
+	var/meteordelay = 2000
+	var/nometeors = 0
+	var/rampupdelta = 5
 	required_players = 0
 
 
@@ -11,17 +12,20 @@
 	world << "<B>The space station has been stuck in a major meteor shower. You must escape from the station or at least live.</B>"
 
 
-/datum/game_mode/meteor/post_setup()
-//	defer_powernet_rebuild = 2//Might help with the lag
-	spawn(meteordelay)
-		nometeors = 0
-	..()
-
-
 /datum/game_mode/meteor/process()
-	if(nometeors) return
-
-	spawn() spawn_meteors(6, meteors_normal)
+	if(nometeors || meteordelay < world.time - round_start_time) 
+		return
+	
+	var/list/wavetype = meteors_normal
+	var/meteorminutes = (world.time - round_start_time - meteordelay) / 10 / 60
+	
+	if (prob(meteorminutes))
+		wavetype = meteors_threatening
+	else if (prob(meteorminutes/2))
+		wavetype = meteors_catastrophic
+	
+	spawn_meteors(Clamp(round(meteorminutes/rampupdelta),1,10), wavetype)
+		
 
 
 /datum/game_mode/meteor/declare_completion()


### PR DESCRIPTION
Removes the spawn, it's not needed, spawn_meteors spawns.

Changes how meteors are disabled by making it just do the math (this is so admins can change this mid round).

Meteor waves now ramp up by the amount of time in the round, 30 minutes should be the old number, but it will keep going until it gets 10 meteors at 50 minutes.

Meteor wave type now ramps up by the amount of time in the round, with more catastrophic meteor builds getting more and more likely as the round goes on.